### PR TITLE
fix: tsc-alias to resolve full paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/adm-zip": "^0.5.5",
         "@types/node": "^20.14.2",
         "ts-node": "^10.9.2",
+        "tsc-alias": "^1.8.10",
         "typescript": "^5.4.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "File util functions to be used within the RDF-Connect ecosystem",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc-alias",
     "prepublishOnly": "tsc",
     "test": "bun test",
     "watch": "tsc -w"
@@ -41,6 +41,7 @@
     "@types/adm-zip": "^0.5.5",
     "@types/node": "^20.14.2",
     "ts-node": "^10.9.2",
+    "tsc-alias": "^1.8.10",
     "typescript": "^5.4.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,10 @@
       "esm": true,
       "experimentalSpecifierResolution": "node"
     },
+    "tsc-alias": {
+      "resolveFullPaths": true,
+      "verbose": false
+    },
     "include": ["src/**/*"],
     "exclude": ["node_modules/**/*"]
   }
-  


### PR DESCRIPTION
Fixing `Cannot find module '/opt/pipeline/node_modules/@rdfc/file-utils-processors-ts/lib/utils/logUtil' imported from /opt/pipeline/node_modules/@rdfc/file-utils-processors-ts/lib/FileUtils.js`